### PR TITLE
Fixing: "TypeError: Invalid attempt to spread non-iterable"

### DIFF
--- a/Chapter02/Recipe7/todo-list/src/components/Todo/Todo.js
+++ b/Chapter02/Recipe7/todo-list/src/components/Todo/Todo.js
@@ -65,19 +65,20 @@ class Todo extends Component {
   }
 
   markAsCompleted = id => {
-    // Finding the task by id...
-    const foundTask = this.state.items.find(task => task.id === id);
-
-    // Updating the completed status...
-    foundTask.completed = true;
-
+    const itensUpdated = this.state.items.map( item => {
+      
+     // Finding the task by id...
+      if(item.id === id){
+        // Updating the completed status...
+        return Object.assign({}, item, {
+          completed: true
+        })
+      }
+      return item
+    })
     // Updating the state with the new updated task...
-    this.setState({
-      items: [
-        ...this.state.items,
-        ...foundTask
-      ]
-    });
+    this.setState({items: itensUpdated})
+
   }
 
   removeTask = id => {


### PR DESCRIPTION
When I tried to run the application with the **spread operator (...)** the error is displayed: **TypeError: Invalid attempt to spread non-iterable instance on the click completed.**

I tried to pass only taskFound without the operator, but what happened was, when I clicked completed, duplicated the item clicked, that is, it was added to the array the item clicked generating a duplicate of the item.

To solve I made the following implementation based on the book: Full-Stack React Projects By Shama Hoque.

```
markAsCompleted = id => {
      const itensUpdated = this.state.items.map( item => {
           if(item.id === id){
               return Object.assign({}, item, {
               completed: true
           })
       }
      return item
     })
     this.setState({items: itensUpdated})
}

```
Where do I first look for the item by **id** and return a new object with the updated completed attribute